### PR TITLE
Catch-all route instead of default_request signal.

### DIFF
--- a/app/app.vala
+++ b/app/app.vala
@@ -122,11 +122,12 @@ app.scope("admin", (adm) => {
 	});
 });
 
-app.default_request.connect((req, res) => {
+app.get("<any:path>", (req, res) => {
 	var template =  new Valum.View.Tpl.from_path("app/templates/404.html");
 
 	template.vars["path"] = req.path;
 
+	res.status = 404;
 	res.append(template.render());
 });
 

--- a/src/route.vala
+++ b/src/route.vala
@@ -15,7 +15,7 @@ namespace Valum {
 			this.callback = callback;
 
 			try {
-				Regex param_regex = new Regex("(<(?:(?:float|int):)?\\w+>)");
+				Regex param_regex = new Regex("(<(?:\\w+:)?\\w+>)");
 				var params = param_regex.split_full(this.rule);
 
 				StringBuilder route = new StringBuilder("^");
@@ -29,15 +29,22 @@ namespace Valum {
 						var cap = p.slice(1, p.length - 1).split(":", 2);
 						var type = cap.length == 1 ? "string" : cap[0];
 						var key = cap.length == 1 ? cap[0] : cap[1];
+
 						// TODO: support any type with a HashMap<string, string>
-						var type_re = type == "int" ? "\\d+" : "\\w+";
+						var types = new HashMap<string, string> ();
+
+						// add default types
+						types["any"]    = ".+";
+						types["int"]    = "\\d+";
+						types["string"] = "\\w+";
+
 						captures.add(key);
-						route.append("(?<%s>%s)".printf(key, type_re));
+						route.append("(?<%s>%s)".printf(key, types[type]));
 					}
 				}
 
 				route.append("$");
-				info("registered %s", route.str);
+				message("registered %s", route.str);
 
 				this.regex = new Regex(route.str, RegexCompileFlags.OPTIMIZE);
 			} catch(RegexError e) {

--- a/src/router.vala
+++ b/src/router.vala
@@ -20,12 +20,6 @@ namespace Valum {
 			res.message.response_body.complete ();
 		}
 
-		// signal called if no route has matched the request
-		public virtual signal void default_request (Request req, Response res) {
-			res.status = 404;
-			warning("could not match %s, fallback to default handler", req.path);
-		}
-
 		public delegate void NestedRouter(Valum.Router app);
 
 		public Router() {
@@ -137,9 +131,6 @@ namespace Valum {
 					return;
 				}
 			}
-
-			// No route has matched
-			this.default_request (req, res);
 
 			this.after_request (req, res);
 		}


### PR DESCRIPTION
It is cleaner to use a catch-all route to handle 404 instead of a
default request.