### PR TITLE
Replaces Regex by Request matcher pattern

### DIFF
--- a/app/app.vala
+++ b/app/app.vala
@@ -38,6 +38,17 @@ app.get("custom-route-type/<permutations:p>", (req, res) => {
 	res.append(req.params["p"]);
 });
 
+// custom matcher
+app.matcher ("GET",
+	// this callback is used to match the route
+	(req) => {
+		return req.path == "/custom-matcher";
+	},
+	// this callback is called if the matcher is successful
+	(req, res) => {
+		res.append ("This route was matched using a custom matcher.");
+	});
+
 // hello world! (compare with Node.js!)
 app.get("hello", (req, res) => {
 	res.mime = "text/plain";

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -18,33 +18,34 @@
           <div class="row">
             <div class="col-md-4">
               <h3>Documentation</h3>
-              <p>
+              <p class="text-justify">
                 Valum provides <a href="http://valum.readthedocs.org/en/latest/">user documentation</a> to get you
                 started with the framework.
               </p>
-              <p>
+              <p class="text-justify">
                 The framework is built upon <a href="https://developer.gnome.org/libsoup/stable/">libsoup</a> and
                 <a href="https://wiki.gnome.org/action/show/Projects/Libgee">Libgee</a> and automated with the
                 <a href="https://code.google.com/p/waf/">waf build system</a>, so reading about all these is a good
                 start.
               </p>
-              <p>
+              <p class="text-justify">
                 The <a href="http://valadoc.org">valadoc.org</a> website provides api specification of most libraries
                 available in Vala.
               </p>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-8">
               <h3>Examples</h3>
               <p>
                 This is a real Vala web application and we got real examples!
               </p>
-              <ul>
+              <ul class="list-inline">
                 <li><a href="/hello">Hello world!</a></li>
                 <li><a href="/hello/">Hello world! (with a trailing slash)</a></li>
                 <li><a href="/hello/world">route parameter</a></li>
                 <li><a href="/users/4/edit">typed route parameter</a></li>
                 <li><a href="/custom-route-type/abc">custom typed route parameter (permutations of abc)</a></li>
                 <li><a href="/custom-regular-expression">route using a custom regular expression</a></li>
+                <li><a href="/custom-matcher">custom matcher</a></li>
                 <li><a href="/custom-method">route using a custom HTTP method</a></li>
                 <li><a href="/admin/fun/hack">scoped routing</a></li>
                 <li><a href="/urlencoded-data/">parse url-encoded data</a></li>
@@ -53,8 +54,6 @@
                 <li><a href="/memcached/get/bar">memcached (get value)</a></li>
                 <li><a href="/memcached/set/bar">memcached (set value)</a></li>
               </ul>
-            </div>
-            <div class="col-md-4">
               <h3>Contributing</h3>
               <p>
                 Valum is hosted on GitHub and developed under the LGPL license.

--- a/docs/route.md
+++ b/docs/route.md
@@ -1,0 +1,108 @@
+Route
+=====
+
+Route associate regular expression that matches request path with a callback
+that is executed on user request.
+
+Rules
+-----
+
+This class implements the rule system designed to simplify regular expression.
+
+The following are rules examples:
+
+ - /user
+ - /user/<id>
+ - /user/<int:id>
+
+These will respectively compile down to the following regular expressions
+
+ - `^/user$`
+ - `^/user/(?<id>\w+)`
+ - `^/user/(?<id>\d+)`
+
+In this example, we call `<id>` a parameter and `<int>` a type. These two
+definitions will be important for the rest of the document.
+
+Types
+-----
+
+Valum provides the following built-in types
+
+ - int that matches `\d+`
+ - string that matches `\w+` (this one is implicit)
+ - any that matches `.+` asad
+
+Undeclared type is assumed to be `string`, this is what implicit meant.
+
+The `ìnt` type is useful for matching non-negative identifier such as database
+primary key.
+
+The `any` type is useful to create catch-all route. The sample application shows
+an example for creating a 404 error page.
+
+```vala
+app.get('<any:path>', (req, res) => {
+    res.status = 404;
+});
+```
+
+It is possible to specify new types using the `types` map in `Router`. This
+example will define the `path` type matching words and slashes.
+
+```vala
+app.types["path"] = "[\\w/]+";
+```
+
+Types are defined at construct time of the `Router` class. It is possible to
+overwrite the built-in type.
+
+If you would like `ìnt` to match negatives integer, you may just do:
+```
+app = new Router ();
+
+app.types["int"] = "-?\d+";
+```
+
+Plumbering with regular expression
+----------------------------------
+
+If the rule system does not suit your needs, it is always possible to use
+regular expression.
+
+```vala
+app.regex ("GET", /^/home/?$/, (req, res) => {
+
+});
+```
+
+Plumbering with Route
+---------------------
+
+In some scenario, you need more than a just matching the request path using a
+regular expression. Internally, Route uses a matcher pattern and it is possible
+to define them yourself.
+
+A matcher consist of a callback matching a given `Request` object.
+
+```vala
+Route.RequestMatcher matcher = (req) => { req.path == "/custom-matcher"; };
+
+app.matcher ("GET", matcher, (req, res) => {
+    res.append ("Matched using a custom matcher.");
+});
+```
+
+You could, for instance, match the request if the user is an administrator and
+fallback to a default route otherwise.
+
+```
+app.matcher ("GET", (req) => {
+    var user = new User (req.query["id"]);
+    return "admin" in user.roles;
+}, (req, res) => {});
+
+app.route ("<any:path>", (req, res) => {
+    res.status = 404;
+});
+```

--- a/src/request.vala
+++ b/src/request.vala
@@ -2,7 +2,7 @@ using Gee;
 
 namespace Valum {
 	public class Request : Object {
-		public HashMap<string, string> params = new HashMap<string, string> ();
+		public Map<string, string> params = new HashMap<string, string> ();
 		public Soup.Message message { construct; get; }
 		public string path {
 			get { return this.message.uri.get_path(); }

--- a/src/router.vala
+++ b/src/router.vala
@@ -118,6 +118,13 @@ namespace Valum {
 		}
 
 		/**
+		 * Bind a callback with a custom method and matcher.
+		 */
+		public void matcher (string method, Route.RequestMatcher matcher, Route.RequestCallback cb) {
+			this.route (method, new Route.from_matcher (this, matcher, cb));
+		}
+
+		/**
 		 * Bind a callback with a custom method and route.
 		 *
 		 * This is a low-level function and should be used with care.
@@ -151,7 +158,7 @@ namespace Valum {
 			var routes = this.routes[req.message.method];
 
 			foreach (var route in routes) {
-				if (route.matches (req)) {
+				if (route.match (req)) {
 
 					// fire the route!
 					route.fire (req, res);

--- a/src/router.vala
+++ b/src/router.vala
@@ -14,7 +14,7 @@ namespace Valum {
 		/**
 		 * Registered routes by HTTP method.
 		 */
-		private Map<string, Gee.List<Route>> routes = new HashMap<string, Gee.List> ();
+		private Map<string, Gee.List<Route>> routes = new HashMap<string, Gee.List<Route>> ();
 
 		/**
 		 * Stack of scope.
@@ -141,9 +141,15 @@ namespace Valum {
 			this.routes[method].add (route);
 		}
 
-		//
-		// Routing helpers
-		//
+		/**
+		 * Add a fragment to the scope stack and nest a router in this
+		 * new environment.
+		 *
+		 * Scoping will only work with rules
+		 *
+		 * @param fragment fragment to push on the scopes stack
+		 * @param router   nested router in the new scoped environment
+		 */
 		public void scope (string fragment, NestedRouter router) {
 			this.scopes.add (fragment);
 			router (this);

--- a/src/router.vala
+++ b/src/router.vala
@@ -114,17 +114,19 @@ namespace Valum {
 		 * @param regex  regular expression matching the request path.
 		 */
 		public void regex (string method, Regex regex, Route.RequestCallback cb) {
-			this.route (method, new Route (this, regex, cb));
+			this.route (method, new Route.from_regex (this, regex, cb));
 		}
 
 		/**
 		 * Bind a callback with a custom method and route.
 		 *
+		 * This is a low-level function and should be used with care.
+		 *
 		 * @param method HTTP method
 		 * @param route  an instance of Route defining the matching process and the
 		 *               callback.
 		 */
-		private void route (string method, Route route) {
+		public void route (string method, Route route) {
 			if (!this.routes.has_key(method)){
 				this.routes[method] = new ArrayList<Route> ();
 			}
@@ -149,7 +151,7 @@ namespace Valum {
 			var routes = this.routes[req.message.method];
 
 			foreach (var route in routes) {
-				if (route.matches (req.path)) {
+				if (route.matches (req)) {
 
 					// fire the route!
 					route.fire (req, res);
@@ -173,5 +175,3 @@ namespace Valum {
 		}
 	}
 }
-
-


### PR DESCRIPTION
This replace the _regex-by-default_ routing system with a more powerful system based on callback.

Instead of having `Regex` that matches `Request`, a `RequestMatcher` callback is applied on the user request and populate its parameters if successful.

This design can allow user to create route that matches based on any kind of condition (eg. database available, user is an administrator, etc...)

The Route.from_rule still uses Regex, but it captures it into a `RequestMatcher` callback in that fashion:

```vala
this.matcher = (req) => {
    if (regex.match (req.path, 0, out match_info)) {
        // populate the request parameters
    }
}
```

This design benefits from the last_matchinfo optimization I did to improve the number of regex matches as it will match and populate in one step. `fire` will only call the callback.