### PR TITLE
Gee only for examples

### DIFF
--- a/src/route.vala
+++ b/src/route.vala
@@ -1,4 +1,3 @@
-using Gee;
 using VSGI;
 
 namespace Valum {
@@ -86,7 +85,7 @@ namespace Valum {
 
 			var param_regex = new Regex ("(<(?:\\w+:)?\\w+>)");
 			var params      = param_regex.split_full (rule);
-			var captures    = new ArrayList<string> ();
+			var captures    = new SList<string> ();
 			var route       = new StringBuilder ("^");
 
 			foreach (var p in params) {
@@ -99,7 +98,7 @@ namespace Valum {
 					var type = cap.length == 1 ? "string" : cap[0];
 					var key  = cap.length == 1 ? cap[0] : cap[1];
 
-					captures.add (key);
+					captures.append (key);
 					route.append ("(?<%s>%s)".printf (key, this.router.types[type]));
 				}
 			}
@@ -112,6 +111,7 @@ namespace Valum {
 			this.matcher = (req) => {
 				MatchInfo match_info;
 				if (regex.match (req.uri.get_path (), 0, out match_info)) {
+					req.params = new HashTable<string, string> (str_hash, str_equal);
 					// populate the request parameters
 					foreach (var capture in captures) {
 						req.params[capture] = match_info.fetch_named (capture);

--- a/src/route.vala
+++ b/src/route.vala
@@ -49,7 +49,7 @@ namespace Valum {
 			this.router   = router;
 			this.callback = callback;
 
-			var captures      = new ArrayList<string> ();
+			var captures      = new SList<string> ();
 			var capture_regex = new Regex ("\\(\\?<(\\w+)>.+\\)");
 			MatchInfo capture_match_info;
 
@@ -57,16 +57,19 @@ namespace Valum {
 			if (capture_regex.match (regex.get_pattern (), 0, out capture_match_info)) {
 				foreach (var capture in capture_match_info.fetch_all ()) {
 					message ("found capture %s in regex %s".printf (capture, regex.get_pattern ()));
-					captures.add (capture);
+					captures.append (capture);
 				}
 			}
 
 			this.matcher = (req) => {
 				MatchInfo match_info;
 				if (regex.match (req.uri.get_path (), 0, out match_info)) {
-					// populate the request parameters
-					foreach (var capture in captures) {
-						req.params[capture] = match_info.fetch_named (capture);
+					if (captures.length () > 0) {
+						// populate the request parameters
+						req.params = new HashTable<string, string> (str_hash, str_equal);
+						foreach (var capture in captures) {
+							req.params[capture] = match_info.fetch_named (capture);
+						}
 					}
 					return true;
 				}
@@ -111,10 +114,12 @@ namespace Valum {
 			this.matcher = (req) => {
 				MatchInfo match_info;
 				if (regex.match (req.uri.get_path (), 0, out match_info)) {
-					req.params = new HashTable<string, string> (str_hash, str_equal);
-					// populate the request parameters
-					foreach (var capture in captures) {
-						req.params[capture] = match_info.fetch_named (capture);
+					if (captures.length () > 0) {
+						// populate the request parameters
+						req.params = new HashTable<string, string> (str_hash, str_equal);
+						foreach (var capture in captures) {
+							req.params[capture] = match_info.fetch_named (capture);
+						}
 					}
 					return true;
 				}

--- a/src/vsgi/fastcgi.vala
+++ b/src/vsgi/fastcgi.vala
@@ -1,4 +1,3 @@
-using Gee;
 using FastCGI;
 
 /**

--- a/src/vsgi/request.vala
+++ b/src/vsgi/request.vala
@@ -18,6 +18,11 @@ namespace VSGI {
 		public const string PATCH   = "PATCH";
 
 		/**
+		 * List of all supported HTTP methods.
+		 */
+		public const string[] METHODS = {OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT, PATCH};
+
+		/**
 		 * Parameters for the request.
 		 *
 		 * These should be extracted from the URI path.
@@ -60,8 +65,8 @@ namespace VSGI {
 			owned get {
 				var cookies = new SList<Soup.Cookie> ();
 
-				foreach (var cookie in this.headers.get_list ("Set-Cookie").split (",")) {
-					cookies.append (Soup.Cookie.parse (cookie, null));
+				foreach (var cookie in this.headers.get_list ("Cookie").split (",")) {
+					cookies.append (Soup.Cookie.parse (cookie, this.uri));
 				}
 
 				return cookies;

--- a/src/vsgi/request.vala
+++ b/src/vsgi/request.vala
@@ -1,5 +1,3 @@
-using Gee;
-
 namespace VSGI {
 
 	/**
@@ -24,7 +22,7 @@ namespace VSGI {
 		 *
 		 * These should be extracted from the URI path.
 		 */
-		public Map<string, string> params = new HashMap<string, string> ();
+		public HashTable<string, string>? params = null;
 
 		/**
 		 * Request HTTP method
@@ -58,12 +56,12 @@ namespace VSGI {
 		 * Cookies will be computed from the Cookie HTTP header everytime they are
 		 * accessed.
 		 */
-		public Gee.List<Soup.Cookie> cookies {
+		public SList<Soup.Cookie> cookies {
 			owned get {
-				var cookies = new ArrayList<Soup.Cookie> ();
+				var cookies = new SList<Soup.Cookie> ();
 
 				foreach (var cookie in this.headers.get_list ("Set-Cookie").split (",")) {
-					cookies.add (Soup.Cookie.parse (cookie, null));
+					cookies.append (Soup.Cookie.parse (cookie, null));
 				}
 
 				return cookies;

--- a/src/vsgi/response.vala
+++ b/src/vsgi/response.vala
@@ -1,5 +1,3 @@
-using Gee;
-
 namespace VSGI {
 
 	/**
@@ -21,12 +19,12 @@ namespace VSGI {
 		 * Property for the Set-Cookie header.
 		 * Set cookies for this Response.
 		 */
-		public Gee.List<Soup.Cookie> cookies {
+		public SList<Soup.Cookie> cookies {
 			owned get {
-				var cookies = new ArrayList<Soup.Cookie> ();
+				var cookies = new SList<Soup.Cookie> ();
 
 				foreach (var cookie in this.headers.get_list ("Set-Cookie").split (",")) {
-					cookies.add (Soup.Cookie.parse (cookie, null));
+					cookies.append (Soup.Cookie.parse (cookie, null));
 				}
 
 				return cookies;

--- a/src/vsgi/soup.vala
+++ b/src/vsgi/soup.vala
@@ -1,4 +1,3 @@
-using Gee;
 using Soup;
 
 /**

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -6,7 +6,9 @@ public int main (string[] args) {
 	Test.init (ref args);
 
 	Test.add_func ("/valum/route/from_rule", test_valum_route_from_rule);
+	Test.add_func ("/valum/route/from_rule/without_captures", test_valum_route_from_rule_without_captures);
 	Test.add_func ("/valum/route/from_regex", test_valum_route_from_regex);
+	Test.add_func ("/valum/route/from_regex/without_captures", test_valum_route_from_regex_without_captures);
 	Test.add_func ("/valum/route/from_matcher", test_valum_route_from_regex);
 	Test.add_func ("/valum/route/match", test_valum_route_match);
 	Test.add_func ("/valum/route/match/not_matching", test_valum_route_match_not_matching);

--- a/tests/valum/test_route.vala
+++ b/tests/valum/test_route.vala
@@ -20,11 +20,37 @@ public void test_valum_route_from_rule () {
 	*/
 }
 
+public void test_valum_route_from_rule_without_captures () {
+	var route  = new Route.from_rule (new Router (), "/", (req, res) => {});
+	var req    = new TestRequest.with_uri (new Soup.URI ("http://localhost/"));
+
+	assert (req.params == null);
+
+	var matches = route.match (req);
+
+	// ensure params are still null if there is no captures
+	assert (matches);
+	assert (req.params == null);
+}
+
 public void test_valum_route_from_regex () {
 	var route  = new Route.from_regex (new Router (), /^\/(?<id>\d+)$/, (req, res) => {});
 	var req    = new TestRequest.with_uri (new Soup.URI ("http://localhost/5"));
 
 	assert (route.match (req));
+}
+
+public void test_valum_route_from_regex_without_captures () {
+	var route  = new Route.from_regex (new Router (), /\//, (req, res) => {});
+	var req    = new TestRequest.with_uri (new Soup.URI ("http://localhost/"));
+
+	assert (req.params == null);
+
+	var matches = route.match (req);
+
+	// ensure params are still null if there is no captures
+	assert (matches);
+	assert (req.params == null);
 }
 
 public void test_valum_route_from_matcher () {
@@ -39,12 +65,13 @@ public void test_valum_route_match () {
 	var route  = new Route.from_rule (new Router (), "/<int:id>", (req, res) => {});
 	var req    = new TestRequest.with_uri (new Soup.URI ("http://localhost/5"));
 
+	assert (req.params == null);
+
 	var matches = route.match (req);
 
 	assert (matches);
 	assert_nonnull (req.params);
 	assert (req.params.contains ("id"));
-
 }
 
 public void test_valum_route_match_not_matching () {
@@ -53,7 +80,9 @@ public void test_valum_route_match_not_matching () {
 
 	// no match and params remains null
 	assert (route.match (req) == false);
+	assert (req.params == null);
 }
+
 
 public void test_route_fire () {
 	var setted = false;


### PR DESCRIPTION
This PR replaces all use of Gee data structure by more adapted GLib ones for the framework internals.

This is especially important for VSGI specification as it has to have a minimum of dependencies. libsoup is like just enough.

I have also improved the data structure over the framework

 - we often traverse and append to routes in `routes` `HashTable`, so it uses a `Queue`
 - scopes uses a real stack (double-ended queue)
 - `HashTable` implementation of GLib is very efficient

The main idea here is to minimize our dependencies and use more efficient data structure for the framework.